### PR TITLE
Fix passing annotations to RedisCluster pod via pod template

### DIFF
--- a/pkg/controller/pod/control_test.go
+++ b/pkg/controller/pod/control_test.go
@@ -60,6 +60,48 @@ func Test_initPod(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "annotations merged and passed",
+			args: args{
+				redisCluster: &rapi.RedisCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testcluster",
+						Namespace: "foo",
+						Annotations: map[string]string{
+							"annotation1": "foo",
+						},
+					},
+					Spec: rapi.RedisClusterSpec{
+						PodTemplate: &kapiv1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"annotation2": "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &kapiv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "rediscluster-testcluster-",
+					Namespace:    "foo",
+					OwnerReferences: []metav1.OwnerReference{{
+						Name:       "testcluster",
+						APIVersion: rapi.GroupVersion.String(),
+						Kind:       rapi.ResourceKind,
+						Controller: boolPtr(true),
+					}},
+					Labels: map[string]string{rapi.ClusterNameLabelKey: "testcluster"},
+					Annotations: map[string]string{
+						rapi.PodSpecMD5LabelKey: string(emptyPodSpecMD5),
+						"annotation1":           "foo",
+						"annotation2":           "bar",
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/pod/utils.go
+++ b/pkg/controller/pod/utils.go
@@ -35,11 +35,26 @@ func CreateRedisClusterLabelSelector(cluster *rapi.RedisCluster) (labels.Selecto
 	return labels.SelectorFromSet(set), nil
 }
 
-// GetAnnotationsSet return a labels.Set of annotation from the RedisCluster
-func GetAnnotationsSet(cluster *rapi.RedisCluster) (labels.Set, error) {
+// GetClusterAnnotationsSet return a labels.Set of annotations from the RedisCluster
+func GetClusterAnnotationsSet(cluster *rapi.RedisCluster) (labels.Set, error) {
 	desiredAnnotations := make(labels.Set)
 	for k, v := range cluster.Annotations {
 		desiredAnnotations[k] = v
+	}
+	return desiredAnnotations, nil
+}
+
+// GetAnnotationsSet return a labels.Set of annotations from the RedisCluster and the PodTemplate
+func GetAnnotationsSet(cluster *rapi.RedisCluster) (labels.Set, error) {
+	desiredAnnotations, err := GetClusterAnnotationsSet(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	if cluster.Spec.PodTemplate != nil {
+		for k, v := range cluster.Spec.PodTemplate.Annotations {
+			desiredAnnotations[k] = v
+		}
 	}
 	return desiredAnnotations, nil
 }

--- a/pkg/controller/poddisruptionbudget_control.go
+++ b/pkg/controller/poddisruptionbudget_control.go
@@ -79,7 +79,7 @@ func (s *PodDisruptionBudgetsControl) CreateRedisClusterPodDisruptionBudget(redi
 
 	}
 
-	desiredAnnotations, err := pod.GetAnnotationsSet(redisCluster)
+	desiredAnnotations, err := pod.GetClusterAnnotationsSet(redisCluster)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/service_control.go
+++ b/pkg/controller/service_control.go
@@ -63,7 +63,7 @@ func (s *ServicesControl) CreateRedisClusterService(redisCluster *rapi.RedisClus
 
 	}
 
-	desiredAnnotations, err := pod.GetAnnotationsSet(redisCluster)
+	desiredAnnotations, err := pod.GetClusterAnnotationsSet(redisCluster)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Includes pod template annotations to RedisCluster pods' final annotations set. To avoid passing pod-related annotations to PodDisruptionBudget and RedisCluster service, I've extracted a separate helper function GetClusterAnnotationsSet.

Resolves #52