### PR TITLE
Update terminatingpod sanity check

### DIFF
--- a/pkg/controller/pod/control.go
+++ b/pkg/controller/pod/control.go
@@ -31,6 +31,8 @@ type RedisClusterControlInterface interface {
 	DeletePod(redisCluster *rapi.RedisCluster, podName string) error
 	// DeletePodNow used to delete now (force) a pod from its name
 	DeletePodNow(redisCluster *rapi.RedisCluster, podName string) error
+	// SetPodLabels used to set a new map of labels to pod
+	SetPodLabels(pod kapiv1.Pod, podLabels map[string]string) error
 }
 
 var _ RedisClusterControlInterface = &RedisClusterControl{}
@@ -74,6 +76,16 @@ func (p *RedisClusterControl) CreatePod(redisCluster *rapi.RedisCluster) (*kapiv
 		return nil, err
 	}
 	return pod, nil
+}
+
+// SetPodLabels used to set a new map of labels to pod
+func (p *RedisClusterControl) SetPodLabels(pod kapiv1.Pod, podLabels map[string]string) error {
+
+	pod.SetLabels(podLabels)
+	if err := p.KubeClient.Update(context.Background(), &pod); err != nil {
+		return err
+	}
+	return nil
 }
 
 // CreatePodOnNode used to create a Pod on the given node

--- a/pkg/controller/sanitycheck/process.go
+++ b/pkg/controller/sanitycheck/process.go
@@ -35,7 +35,7 @@ func RunSanityChecks(ctx context.Context, admin redis.AdminInterface, config *co
 	}
 
 	// delete pods that are stuck in terminating state
-	if actionDone, err = FixTerminatingPods(cluster, podControl, 5*time.Minute, dryRun); err != nil {
+	if actionDone, err = FixTerminatingPods(cluster, podControl, 1*time.Minute, dryRun); err != nil {
 		return actionDone, err
 	} else if actionDone {
 		glog.V(2).Infof("FixTerminatingPods executed an action on the cluster (dryRun: %v)", dryRun)

--- a/pkg/controller/sanitycheck/untrustednodes_test.go
+++ b/pkg/controller/sanitycheck/untrustednodes_test.go
@@ -224,6 +224,11 @@ func (f *Fakecontrol) DeletePodNow(redisCluster *rapi.RedisCluster, podName stri
 	return nil
 }
 
+// SetPodLabels used to set labels for a pod
+func (f *Fakecontrol) SetPodLabels(pod kapiv1.Pod, labels map[string]string) error {
+	return nil
+}
+
 func newPod(name, vmName, ip string) kapiv1.Pod {
 	return kapiv1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name}, Spec: kapiv1.PodSpec{NodeName: vmName}, Status: kapiv1.PodStatus{PodIP: ip}}
 }


### PR DESCRIPTION
The operator will now disassociate pods that are stuck in terminating state for over a minute.
Also, it will add a label `"redis-operator.k8s.io/marked-for-termination" = "true"`, in case the pods need to be cleaned up later.

Resolves #84 