### PR TITLE
Use the chart version for the operator image tag

### DIFF
--- a/charts/operator-for-redis/templates/deployment.yaml
+++ b/charts/operator-for-redis/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           - name: NAMESPACE


### PR DESCRIPTION
The current operator chart always requires `--set image.tag={whatever}`, as the `.Chart.AppVersion` variable does not exist.