### PR TITLE
Update PodDisruptionBudget in RedisCluster reconcil

### DIFF
--- a/hack/test-local.sh
+++ b/hack/test-local.sh
@@ -31,7 +31,7 @@ echo "create RBAC for rediscluster"
 #kubectl create -f $GIT_ROOT/examples/RedisCluster_RBAC.yaml
 
 printf  "create and install the redis operator in a dedicate namespace"
-until helm install -n operator --set image.tag=$TAG chart/redis-operator; do sleep 1; printf "."; done
+until helm install operator --set image.tag=$TAG charts/operator-for-redis; do sleep 1; printf "."; done
 echo
 
 printf "Waiting for redis-operator deployment to complete."

--- a/hack/test-local.sh
+++ b/hack/test-local.sh
@@ -35,7 +35,7 @@ until helm install -n operator --set image.tag=$TAG chart/redis-operator; do sle
 echo
 
 printf "Waiting for redis-operator deployment to complete."
-until [ $(kubectl get deployment operator-redis-operator -ojsonpath="{.status.conditions[?(@.type=='Available')].status}") == "True" ] > /dev/null 2>&1; do sleep 1; printf "."; done
+until [ $(kubectl get deployment operator-operator-for-redis -ojsonpath="{.status.conditions[?(@.type=='Available')].status}") == "True" ] > /dev/null 2>&1; do sleep 1; printf "."; done
 echo
 
 echo "[[[ Run End2end test ]]] "

--- a/hack/test-local.sh
+++ b/hack/test-local.sh
@@ -9,15 +9,6 @@ minikube start
 echo "Create the missing rolebinding for k8s dashboard"
 kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
 
-echo "Init the helm tiller"
-kubectl -n kube-system create sa tiller
-kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
-helm init --service-account tiller
-
-printf "Waiting for tiller deployment to complete."
-until [ $(kubectl get deployment -n kube-system tiller-deploy -ojsonpath="{.status.conditions[?(@.type=='Available')].status}") == "True" ] > /dev/null 2>&1; do sleep 1; printf "."; done
-echo
-
 eval $(minikube docker-env)
 echo "Install the redis-cluster operator"
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -234,6 +234,17 @@ func (c *Controller) syncCluster(ctx context.Context, redisCluster *rapi.RedisCl
 			glog.Errorf("RedisCluster-Operator.Reconcile unable to create podDisruptionBudget associated with RedisCluster: %s/%s", redisCluster.Namespace, redisCluster.Name)
 			return result, err
 		}
+	} else {
+		needUpdatePDB, err := c.podDisruptionBudgetControl.NeedUpdateRedisClusterPodDisruptionBudget(redisCluster, redisClusterPodDisruptionBudget)
+		if err != nil {
+			return result, err
+		}
+		if needUpdatePDB {
+			if _, err = c.podDisruptionBudgetControl.UpdateRedisClusterPodDisruptionBudget(redisCluster, redisClusterPodDisruptionBudget); err != nil {
+				glog.Errorf("RedisCluster-Operator.Reconcile unable to update podDisruptionBudget associated with RedisCluster: %s/%s", redisCluster.Namespace, redisCluster.Name)
+				return result, err
+			}
+		}
 	}
 
 	redisPods, err := c.podControl.GetRedisClusterPods(redisCluster)

--- a/pkg/controller/poddisruptionbudget_control_test.go
+++ b/pkg/controller/poddisruptionbudget_control_test.go
@@ -1,0 +1,134 @@
+package controller
+
+import (
+	"testing"
+
+	rapi "github.com/IBM/operator-for-redis-cluster/api/v1alpha1"
+	"github.com/gogo/protobuf/proto"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestPodDisruptionBudgetsControl_desiredRedisClusterPodDisruptionBudget(t *testing.T) {
+	boolPtr := func(value bool) *bool {
+		return &value
+	}
+
+	type fields struct {
+		KubeClient client.Client
+		Recorder   record.EventRecorder
+	}
+	type args struct {
+		redisCluster *rapi.RedisCluster
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *policyv1.PodDisruptionBudget
+		wantErr bool
+	}{
+		{
+			name: "3 primary, replica=1",
+			args: args{
+				redisCluster: &rapi.RedisCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rediscluster",
+					},
+					Spec: rapi.RedisClusterSpec{
+						NumberOfPrimaries: proto.Int32(3),
+						ReplicationFactor: proto.Int32(1),
+					},
+				},
+			},
+			want: &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rediscluster",
+					Labels: map[string]string{
+						rapi.ClusterNameLabelKey: "rediscluster",
+					},
+					Annotations: map[string]string{},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name:       "rediscluster",
+							APIVersion: rapi.GroupVersion.String(),
+							Kind:       rapi.ResourceKind,
+							Controller: boolPtr(true),
+						},
+					},
+				},
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{
+						IntVal: 5,
+					},
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							rapi.ClusterNameLabelKey: "rediscluster",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "2 primary, replica=1",
+			args: args{
+				redisCluster: &rapi.RedisCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rediscluster",
+					},
+					Spec: rapi.RedisClusterSpec{
+						NumberOfPrimaries: proto.Int32(2),
+						ReplicationFactor: proto.Int32(1),
+					},
+				},
+			},
+			want: &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rediscluster",
+					Labels: map[string]string{
+						rapi.ClusterNameLabelKey: "rediscluster",
+					},
+					Annotations: map[string]string{},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Name:       "rediscluster",
+							APIVersion: rapi.GroupVersion.String(),
+							Kind:       rapi.ResourceKind,
+							Controller: boolPtr(true),
+						},
+					},
+				},
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{
+						IntVal: 3,
+					},
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							rapi.ClusterNameLabelKey: "rediscluster",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &PodDisruptionBudgetsControl{
+				KubeClient: tt.fields.KubeClient,
+				Recorder:   tt.fields.Recorder,
+			}
+			got, err := s.desiredRedisClusterPodDisruptionBudget(tt.args.redisCluster)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PodDisruptionBudgetsControl.desiredRedisClusterPodDisruptionBudget() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !equality.Semantic.DeepEqual(got, tt.want) {
+				t.Errorf("PodDisruptionBudgetsControl.desiredRedisClusterPodDisruptionBudget() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -45,7 +45,7 @@ var _ = Describe("RedisCluster CRUD operations", func() {
 
 		Eventually(framework.CreateRedisClusterConfigMapFunc(kubeClient, cluster), "5s", "1s").ShouldNot(HaveOccurred())
 
-		Eventually(framework.IsPodDisruptionBudgetCreatedFunc(kubeClient, cluster), "5s", "1s").ShouldNot(HaveOccurred())
+		Eventually(framework.IsPodDisruptionBudgetCreatedFunc(kubeClient, cluster, int32(5)), "5s", "1s").ShouldNot(HaveOccurred())
 
 		Eventually(framework.IsRedisClusterStartedFunc(kubeClient, cluster), "8m", "5s").ShouldNot(HaveOccurred())
 
@@ -86,6 +86,8 @@ lazyfree-lazy-expire yes`,
 			Eventually(framework.UpdateConfigRedisClusterFunc(kubeClient, cluster, &nbPrimary, nil), "5s", "1s").ShouldNot(HaveOccurred())
 
 			Eventually(framework.IsRedisClusterStartedFunc(kubeClient, cluster), "5m", "5s").ShouldNot(HaveOccurred())
+
+			Eventually(framework.IsPodDisruptionBudgetCreatedFunc(kubeClient, cluster, int32(7)), "5s", "1s").ShouldNot(HaveOccurred())
 
 			Eventually(framework.ZonesBalancedFunc(kubeClient, cluster), "10s", "1s").ShouldNot(HaveOccurred())
 		})


### PR DESCRIPTION
Resolves https://github.com/IBM/operator-for-redis-cluster/issues/104

- Update PodDisruptionBudgets when RedisCluster is reconciled.
- Extraction of desiredPodDisruptionBudget common to PodDisruptionBudgetsControl processing. and add test.
- Fixed an issue with local integration tests not working. And added PodDisruptionBudget update test.

`./hack/test-local.sh` passed

```
+ ./e2e.test --kubeconfig=/Users/****/.kube/config --image-tag=latest --ginkgo.slowSpecThreshold 260
Running Suite: RedisCluster Suite
=================================
Random Seed: 1680103636
Will run 11 of 11 specs

•••••••••••
Ran 11 of 11 Specs in 532.254 seconds
SUCCESS! -- 11 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```
