### PR TITLE
Replace md5 hashing with SHA2 hashing algorithms

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -3,8 +3,8 @@ package v1alpha1
 const (
 	// ClusterNameLabelKey Label key for the ClusterName
 	ClusterNameLabelKey string = "redis-operator.k8s.io/cluster-name"
-	// PodSpecMD5LabelKey label key for the PodSpec MD5 hash
-	PodSpecMD5LabelKey string = "redis-operator.k8s.io/podspec-md5"
+	// PodSpecSHA2LabelKey label key for the PodSpec SHA2 hash
+	PodSpecSHA2LabelKey string = "redis-operator.k8s.io/podspec-sha2"
 	// UnknownZone label for unknown zone
 	UnknownZone string = "unknown"
 )

--- a/pkg/controller/actions.go
+++ b/pkg/controller/actions.go
@@ -547,7 +547,7 @@ func scaleDown(ctx context.Context, admin redis.AdminInterface, cluster *rapi.Re
 }
 
 func getNodesWithNewHash(cluster *rapi.RedisCluster, nodes redis.Nodes) (redis.Nodes, redis.Nodes, error) {
-	clusterPodSpecHash, err := podctrl.GenerateMD5Spec(&cluster.Spec.PodTemplate.Spec)
+	clusterPodSpecHash, err := podctrl.GenerateSHA2Spec(&cluster.Spec.PodTemplate.Spec)
 	if err != nil {
 		return redis.Nodes{}, redis.Nodes{}, err
 	}
@@ -556,14 +556,14 @@ func getNodesWithNewHash(cluster *rapi.RedisCluster, nodes redis.Nodes) (redis.N
 		if n.Pod == nil {
 			return false
 		}
-		return comparePodSpecMD5Hash(clusterPodSpecHash, n.Pod)
+		return comparePodSpecSHA2Hash(clusterPodSpecHash, n.Pod)
 	})
 	// nodes with old pod spec version
 	oldNodes := nodes.FilterByFunc(func(n *redis.Node) bool {
 		if n.Pod == nil {
 			return false
 		}
-		return !comparePodSpecMD5Hash(clusterPodSpecHash, n.Pod)
+		return !comparePodSpecSHA2Hash(clusterPodSpecHash, n.Pod)
 	})
 
 	return oldNodes, newNodes, nil

--- a/pkg/controller/checks.go
+++ b/pkg/controller/checks.go
@@ -251,12 +251,12 @@ func needRollingUpdate(cluster *rapi.RedisCluster) bool {
 }
 
 func comparePodsWithPodTemplate(cluster *rapi.RedisCluster) bool {
-	clusterPodSpecHash, _ := podctrl.GenerateMD5Spec(&cluster.Spec.PodTemplate.Spec)
+	clusterPodSpecHash, _ := podctrl.GenerateSHA2Spec(&cluster.Spec.PodTemplate.Spec)
 	for _, node := range cluster.Status.Cluster.Nodes {
 		if node.Pod == nil {
 			continue
 		}
-		if !comparePodSpecMD5Hash(clusterPodSpecHash, node.Pod) {
+		if !comparePodSpecSHA2Hash(clusterPodSpecHash, node.Pod) {
 			return false
 		}
 	}
@@ -280,8 +280,8 @@ func compareConfig(oldConfig, newConfig map[string]string) map[string]string {
 	return configChanges
 }
 
-func comparePodSpecMD5Hash(hash string, pod *kapi.Pod) bool {
-	if val, ok := pod.Annotations[rapi.PodSpecMD5LabelKey]; ok {
+func comparePodSpecSHA2Hash(hash string, pod *kapi.Pod) bool {
+	if val, ok := pod.Annotations[rapi.PodSpecSHA2LabelKey]; ok {
 		if val != hash {
 			return false
 		}

--- a/pkg/controller/checks_test.go
+++ b/pkg/controller/checks_test.go
@@ -1143,9 +1143,9 @@ func Test_comparePodSpec(t *testing.T) {
 	podSpec1 := kapiv1.PodSpec{Containers: []kapiv1.Container{{Name: "redis-node", Image: "redis-node:3.0.3"}}}
 	podSpec2 := kapiv1.PodSpec{Containers: []kapiv1.Container{{Name: "redis-node", Image: "redis-node:4.0.8"}}}
 	podSpec3 := kapiv1.PodSpec{Containers: []kapiv1.Container{{Name: "redis-node", Image: "redis-node:3.0.3"}, {Name: "prometheus", Image: "prometheus-exporter:latest"}}}
-	hashspec1, _ := ctrlpod.GenerateMD5Spec(&podSpec1)
-	hashspec2, _ := ctrlpod.GenerateMD5Spec(&podSpec2)
-	hashspec3, _ := ctrlpod.GenerateMD5Spec(&podSpec3)
+	hashspec1, _ := ctrlpod.GenerateSHA2Spec(&podSpec1)
+	hashspec2, _ := ctrlpod.GenerateSHA2Spec(&podSpec2)
+	hashspec3, _ := ctrlpod.GenerateSHA2Spec(&podSpec3)
 	type args struct {
 		spec string
 		pod  *kapiv1.Pod
@@ -1161,7 +1161,7 @@ func Test_comparePodSpec(t *testing.T) {
 				spec: hashspec1,
 				pod: &kapiv1.Pod{
 					ObjectMeta: kmetav1.ObjectMeta{
-						Annotations: map[string]string{rapi.PodSpecMD5LabelKey: string(hashspec1)},
+						Annotations: map[string]string{rapi.PodSpecSHA2LabelKey: string(hashspec1)},
 					},
 					Spec: podSpec1,
 				},
@@ -1174,7 +1174,7 @@ func Test_comparePodSpec(t *testing.T) {
 				spec: hashspec1,
 				pod: &kapiv1.Pod{
 					ObjectMeta: kmetav1.ObjectMeta{
-						Annotations: map[string]string{rapi.PodSpecMD5LabelKey: string(hashspec2)},
+						Annotations: map[string]string{rapi.PodSpecSHA2LabelKey: string(hashspec2)},
 					},
 					Spec: podSpec2},
 			},
@@ -1186,7 +1186,7 @@ func Test_comparePodSpec(t *testing.T) {
 				spec: hashspec1,
 				pod: &kapiv1.Pod{
 					ObjectMeta: kmetav1.ObjectMeta{
-						Annotations: map[string]string{rapi.PodSpecMD5LabelKey: string(hashspec3)},
+						Annotations: map[string]string{rapi.PodSpecSHA2LabelKey: string(hashspec3)},
 					},
 					Spec: podSpec3},
 			},
@@ -1195,7 +1195,7 @@ func Test_comparePodSpec(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := comparePodSpecMD5Hash(tt.args.spec, tt.args.pod); got != tt.want {
+			if got := comparePodSpecSHA2Hash(tt.args.spec, tt.args.pod); got != tt.want {
 				t.Errorf("comparePodSpec() = %v, want %v", got, tt.want)
 			}
 		})
@@ -1223,12 +1223,12 @@ func newPodWithContainer(name string, containersInfos map[string]string) *kapiv1
 		Containers: containers,
 	}
 
-	hash, _ := ctrlpod.GenerateMD5Spec(&spec)
+	hash, _ := ctrlpod.GenerateSHA2Spec(&spec)
 
 	pod := &kapiv1.Pod{
 		ObjectMeta: kmetav1.ObjectMeta{
 			Name:        name,
-			Annotations: map[string]string{rapi.PodSpecMD5LabelKey: string(hash)},
+			Annotations: map[string]string{rapi.PodSpecSHA2LabelKey: string(hash)},
 		},
 		Spec: spec,
 	}

--- a/pkg/controller/pod/control_test.go
+++ b/pkg/controller/pod/control_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Test_initPod(t *testing.T) {
-	emptyPodSpecMD5, _ := GenerateMD5Spec(&kapiv1.PodSpec{})
+	emptyPodSpecSHA2, _ := GenerateSHA2Spec(&kapiv1.PodSpec{})
 
 	type args struct {
 		redisCluster *rapi.RedisCluster
@@ -55,7 +55,7 @@ func Test_initPod(t *testing.T) {
 						Controller: boolPtr(true),
 					}},
 					Labels:      map[string]string{rapi.ClusterNameLabelKey: "testcluster"},
-					Annotations: map[string]string{rapi.PodSpecMD5LabelKey: string(emptyPodSpecMD5)},
+					Annotations: map[string]string{rapi.PodSpecSHA2LabelKey: string(emptyPodSpecSHA2)},
 				},
 			},
 			wantErr: false,
@@ -94,9 +94,9 @@ func Test_initPod(t *testing.T) {
 					}},
 					Labels: map[string]string{rapi.ClusterNameLabelKey: "testcluster"},
 					Annotations: map[string]string{
-						rapi.PodSpecMD5LabelKey: string(emptyPodSpecMD5),
-						"annotation1":           "foo",
-						"annotation2":           "bar",
+						rapi.PodSpecSHA2LabelKey: string(emptyPodSpecSHA2),
+						"annotation1":            "foo",
+						"annotation2":            "bar",
 					},
 				},
 			},


### PR DESCRIPTION
md5 is outdated now and many automated code checkers might complain for it's usage even though it is not being used for any security purposes. This is just to future proof things.